### PR TITLE
Link to uscbiostats/aphylo

### DIFF
--- a/Phylogenetics.md
+++ b/Phylogenetics.md
@@ -262,7 +262,7 @@ See the `r view("Epidemiology")` task view for details about packages useful for
 
 ### Omics
 
-- `r pkg("aphylo")` implements a parsimonious evolutionary model to analyze and predict gene-functional annotations in phylogenetic trees.
+- `r github("uscbiostats/aphylo")` implements a parsimonious evolutionary model to analyze and predict gene-functional annotations in phylogenetic trees.
 - `r pkg("CALANGO")` can be used to search for annotation terms (e.g., Pfam IDs, GO terms or superfamilies) associated with a quantitative/rank variable.
 - `r github("hr1912/TreeExp")` can be used to perform comparative analyses of gene expression in a phylogenetic context.
 - See the `r view("Omics")` task view for details about other useful packages.


### PR DESCRIPTION
`aphylo` is archived on CRAN, per #22.  It would be best to reach out to @uscbiostats to see whether they have plans to reinstate the package.  As there has been no activity on the github repo for two years, this PR replaces the link to the archived CRAN package with a link to the GitHub repo for the package.  If the package is no longer in active use we might consider removing it from the task list?