### PR TITLE
switch to new rocker/r2u-based validate-ctv GHA with improved perform…

### DIFF
--- a/.github/workflows/validate-ctv.yml
+++ b/.github/workflows/validate-ctv.yml
@@ -13,6 +13,8 @@ on:
     paths:
       - '.github/workflows/validate-ctv.yml'
       - 'Phylogenetics.md'
+  schedule:
+    - cron: '30 5 1 * *'
 
 name: Validate task view
 


### PR DESCRIPTION
Hi Will @willgearty, we have updated our [cran-task-views/ctv/validate-ctv](https://github.com/cran-task-views/ctv/blob/main/validate-ctv/action.yml) GitHub action. It now uses the `rocker/r2u` container which speeds up running the action. Also, we have streamlined the R code of the action a bit. This includes an improved implementation of the check for "new" archived packages (comparing against CRAN rather than just a different version of the .md on GitHub), see my comments in https://github.com/cran-task-views/ctv/pull/66

Therefore I suggest here to use the new vanilla `validate-ctv` workflow in this PR. If you want to improve the specification for your repository, you are of course very welcome to do so. You are also welcome to raise a new issue or PR if you think that the new action should be improved in general.