### PR TITLE
Updated links for paleoPhylo and splits

### DIFF
--- a/Phylogenetics.md
+++ b/Phylogenetics.md
@@ -70,6 +70,7 @@ Packages within the task view fall within one or more of the following task cate
 - `r pkg("dendextend")` can manipulate dendrograms, including subdividing trees, adding leaves, and more.
 - `r pkg("castor")` can be used to manipulate extremely large trees (up to millions of tips).
 - `r pkg("phytools")` can slice a tree at a pre-specified point, add taxa randomly to a tree, add species to genera, bind a single tip to a tree or two trees together, collapse clades on a tree using a clickable interface, perform midpoint rooting, paint a user-specified discrete character regime onto a tree to create a `"simmap"` object by various methods, convert a tree with a mapped character into a simple `"phylo"` object with unbranching nodes or a root edge into a single unbranching node, and other things.
+- `r pkg("treesliceR")` has funcitons for slicing phylogenies to be used in time-stratified analyses.
 
 ### Tree visualization
 
@@ -83,6 +84,7 @@ Packages within the task view fall within one or more of the following task cate
 - `r pkg("ggmuller")` allows plotting a phylogeny along with frequency dynamics.
 - `r pkg("RPANDA")` can be used to plot the spectral density and eigenvalues of a phylogeny.
 - `r pkg("diversitree")` has an unexported function called "plot2.phylo()" which allows for the production of very lightweight PDF outputs of speciose trees (can be called via `diversitree:::plot2.phylo()`).
+- `r pkg("treesliceR")` has functions to plot rates of accumulation of phylogenetic indexes.
 
 ### Tree comparison
 
@@ -126,7 +128,7 @@ Packages within the task view fall within one or more of the following task cate
 - `r pkg("phangorn")` can infer ultrametric and tipdated phylogenies with a strict clock model direct from sequences.
 - `r github("dosreislab/bppr")` calibrates phylogenies from the program [BPP](https://github.com/bpp/bpp). A tutorial is available at [https://dosreislab.github.io/2018/08/31/bppr.html](https://dosreislab.github.io/2018/08/31/bppr.html)
 - `r github("dosreislab/mcmc3r")` calculates the marginal likelihood in divergence time estimation using MCMCtree from the suite [PAML](https://github.com/abacus-gene/paml). It also calculates the block bootstrap for error estimation in marginal likelihood calculation.
-- `r pkg("tbea")` allows to carry out multiple pre- (e.g. fitting densities to calibration quantiles, matrix and tree format conversion and matrix concatenation) and post-processing (e.g., summary of posterior tree samples, plotting prior vs. posterior estimates, measuring distribution similarity) tasks in Bayesian divergence time estimation. It has tools for summarizing collections of distributions (e.g. multiple estimates for the time of a biogeographic event, the origination time of a group where multiple estimates are available) which can be useful on their own or as a way to specify secondary caliibrations.
+- `r pkg("tbea")` allows to carry out multiple pre- (e.g. fitting densities to calibration quantiles, matrix and tree format conversion and matrix concatenation) and post-processing (e.g., summary of posterior tree samples, plotting prior vs. posterior estimates, measuring distribution similarity) tasks in Bayesian divergence time estimation. It has tools for summarizing collections of distributions (e.g. multiple estimates for the time of a biogeographic event, the origination time of a group where multiple estimates are available) which can be useful on their own or as a way to specify secondary calibrations. It offers a dedicated [website](https://gaballench.github.io/tbea/) with HTML-rendered vignettes.
 
 ### Tree simulations
 
@@ -216,7 +218,7 @@ Packages within the task view fall within one or more of the following task cate
 - `r pkg("secsse")` can be used to fit diversification models with a multistate observed trait and a hidden trait.
 - `r pkg("phytools")` can compute and visualize a lineages-through-time (LTT) plot, and calculate Pybus and Harvey's (2000) gamma statistic.
 - `r pkg("CRABS")` features tools for exploring congruent phylogenetic birth-death models (see Louca and Pennell 2020).
-
+- `r pkg("treesliceR")` has functions to calculate rates of accumulation of phylogenetic indexes.
 
 ## Phylogenetics in specific fields
 
@@ -230,7 +232,7 @@ Packages within the task view fall within one or more of the following task cate
 - `r pkg("paleoTS")` can be used to analyze paleontological time series data using a likelihood-based framework for fitting and comparing models (using a model testing approach) of phyletic evolution (based on the random walk or stasis model).
 - `r pkg("strap")` can do stratigraphic analysis of phylogenetic trees.
 - `r github("rachelwarnock/fbdR")` can be used to estimate diversification rates from phylogenetic trees and fossil occurrence data.
-- `r pkg("tbea")` has tools for estimating confidence intervals on stratigraphic end points and code for summarizing multiple distributions describing the same parameter.
+- `r pkg("tbea")` has tools for estimating confidence intervals on stratigraphic end points and code for summarizing multiple distributions describing the same parameter. It offers a dedicated [website](https://gaballench.github.io/tbea/) with HTML-rendered vignettes.
 - R offers a wealth of other options for general-purpose time series modeling, many of which are listed in the `r view("TimeSeries")` task view.
 
 ### Community and microbial ecology
@@ -293,7 +295,7 @@ See the `r view("Epidemiology")` task view for details about packages useful for
 - `r pkg("Revticulate")` can be used to interact with [RevBayes](https://revbayes.github.io/) from within R, while `r pkg("RevGadgets")` can be used to process the output generated by RevBayes.
 - `r github("dosreislab/bppr")` can prepare the control files for doing model selection for comparing competing species trees using [BPP](https://github.com/bpp/bpp). A tutorial is available at [https://dosreislab.github.io/2018/08/31/bppr.html](https://dosreislab.github.io/2018/08/31/bppr.html)
 - `r github("dosreislab/mcmc3r")` can prepare the control files for carrying out divergence time estimation using MCMCtree from the suite [PAML](https://github.com/abacus-gene/paml). It also generates morphological alignments in phylip format for using continuous trait models in divergence time estimation in MCMCtree.
-- `r pkg("tbea")` has code for post-analysis summarization and plotting of trace files from Bayesian phylogenetic programs such as Beast2, MrBayes, RevBayes, and MCMCTree.
+- `r pkg("tbea")` has code for post-analysis summarization and plotting of trace files from Bayesian phylogenetic programs such as Beast2, MrBayes, RevBayes, and MCMCTree. It offers a dedicated [website](https://gaballench.github.io/tbea/) with HTML-rendered vignettes.
 
 
 ## References

--- a/Phylogenetics.md
+++ b/Phylogenetics.md
@@ -115,7 +115,6 @@ Packages within the task view fall within one or more of the following task cate
 - `r pkg("phyclust")` can cluster sequences.
 - `r pkg("phytools")` can build trees using MRP supertree estimation and least squares.
 - `r github("helixcn/phylotools")` can build supermatrices for analyses in other software.
-- `r pkg("EvoPhylo")` can be used to perform automated morphological character partitioning for bayesian phylogenetic analyses that are performed with [MrBayes](http://nbisweden.github.io/MrBayes/) and [BEAST2](https://www.beast2.org/). It can also be used to analyze the macroevolutionary parameter outputs from such analyses.
 - `r bioc("fastreeR")` can be used to calculate distances, build phylogenetic trees, or perform hierarchical clustering between the samples of a VCF or FASTA file.
 - `r github("uyedaj/rphenoscate")` facilitates analysis of "inapplicable" characters – such as morphological characters that are dependent on a parent trait – by constructing formal character hierarchies and the corresponding rate matrices (Tarasov 2023).
 
@@ -188,6 +187,7 @@ Packages within the task view fall within one or more of the following task cate
 - `r pkg("convevol")` and `r pkg("windex")` can both test for convergent evolution on a phylogeny.
 - `r pkg("Claddis")` can be used to measure morphological diversity from discrete character data and evolutionary tempo on phylogenetic trees.
 - `r pkg("do3PCA")` can be used to estimate probabilistic phylogenetic Principal Component Analysis (PCA), including methods to implement alternative models of trait evolution including Brownian motion (BM), Ornstein-Uhlenbeck (OU), Early Burst (EB), and Pagel's lambda.
+- `r pkg("EvoPhylo")` calculates the mode of selection upon morphological characters based on their rates of evolution, besides other statistics and plots for phenotypic rates.
 
 ### Trait simulations
 
@@ -220,6 +220,8 @@ Packages within the task view fall within one or more of the following task cate
 - `r pkg("phytools")` can compute and visualize a lineages-through-time (LTT) plot, and calculate Pybus and Harvey's (2000) gamma statistic.
 - `r pkg("CRABS")` features tools for exploring congruent phylogenetic birth-death models (see Louca and Pennell 2020).
 - `r pkg("treesliceR")` has functions to calculate rates of accumulation of phylogenetic indexes.
+- `r pkg("EvoPhylo")` processes the output and summary statistics with visualization plots for rates of diversification and fossilization derived from analyses using the FBD model.
+
 
 ## Phylogenetics in specific fields
 
@@ -298,6 +300,7 @@ See the `r view("Epidemiology")` task view for details about packages useful for
 - `r github("dosreislab/mcmc3r")` can prepare the control files for carrying out divergence time estimation using MCMCtree from the suite [PAML](https://github.com/abacus-gene/paml). It also generates morphological alignments in phylip format for using continuous trait models in divergence time estimation in MCMCtree.
 - `r pkg("tbea")` has code for post-analysis summarization and plotting of trace files from Bayesian phylogenetic programs such as Beast2, MrBayes, RevBayes, and MCMCTree. It offers a dedicated [website](https://gaballench.github.io/tbea/) with HTML-rendered vignettes.
 - `r github("lfabreti/convenience")` is a package for assessing Bayesian convergence both in continuous and discrete (topology) parameters from analyses using Bayesian phylogenetic programs.
+- `r pkg("EvoPhylo")` allows easy post-processing of macroevolutionary parameters from the outputs of Mr.Bayes and BEAST2.
 
 ## References
 

--- a/Phylogenetics.md
+++ b/Phylogenetics.md
@@ -129,6 +129,7 @@ Packages within the task view fall within one or more of the following task cate
 - `r github("dosreislab/bppr")` calibrates phylogenies from the program [BPP](https://github.com/bpp/bpp). A tutorial is available at [https://dosreislab.github.io/2018/08/31/bppr.html](https://dosreislab.github.io/2018/08/31/bppr.html)
 - `r github("dosreislab/mcmc3r")` calculates the marginal likelihood in divergence time estimation using MCMCtree from the suite [PAML](https://github.com/abacus-gene/paml). It also calculates the block bootstrap for error estimation in marginal likelihood calculation.
 - `r pkg("tbea")` allows to carry out multiple pre- (e.g. fitting densities to calibration quantiles, matrix and tree format conversion and matrix concatenation) and post-processing (e.g., summary of posterior tree samples, plotting prior vs. posterior estimates, measuring distribution similarity) tasks in Bayesian divergence time estimation. It has tools for summarizing collections of distributions (e.g. multiple estimates for the time of a biogeographic event, the origination time of a group where multiple estimates are available) which can be useful on their own or as a way to specify secondary calibrations. It offers a dedicated [website](https://gaballench.github.io/tbea/) with HTML-rendered vignettes.
+- `r github("mongiardino/chronospace")` allows exploration of time-tree parameter distributions and measures of sensitivity when carrying out multiple analyses, as well as graphical tools for examining these measures.
 
 ### Tree simulations
 

--- a/Phylogenetics.md
+++ b/Phylogenetics.md
@@ -75,7 +75,7 @@ Packages within the task view fall within one or more of the following task cate
 ### Tree visualization
 
 - `r pkg("ape")`, `r pkg("adephylo")`, `r pkg("phylobase")`, `r pkg("phytools")`, `r pkg("ouch")`, and `r pkg("dendextend")` have functions for plotting trees; several of these have options for branch or taxon coloring based on some criterion (ancestral state, tree structure, etc.). In addition, `r pkg("phytools")` has substantial functionality to plot comparative data at the tips of the tree, graph the results of comparative analyses, and plot co-phylogenies.
-- `r rforge("paleoPhylo")` and `r pkg("paleotree")` are specialized for drawing paleobiological phylogenies.
+- `r github("tomezard/paleoPhylo")` and `r pkg("paleotree")` are specialized for drawing paleobiological phylogenies.
 - `r github("heibl/viper")` can be used to annotate phylogenies with branch support, HPD intervals, and more.
 - The popular R visualization package `r pkg("ggplot2")` can be extended by `r bioc("ggtree")` and `r bioc("ggtreeExtra")` to visualize phylogenies, and a geological timescale can be added using `r pkg("deeptime")`.
 - `r pkg("strap")` can be used to add a geological timescale to a phylogeny, along with stratigraphic ranges.
@@ -273,7 +273,7 @@ See the `r view("Epidemiology")` task view for details about packages useful for
 
 ### Gene tree--species tree and species delimitation
 
-- `r rforge("splits")` uses a gene tree to infer species limits based on GMYC (Generalized Mixed Yule Coalescent).
+- `r github("tomezard/splits")` uses a gene tree to infer species limits based on GMYC (Generalized Mixed Yule Coalescent).
 - `r github("emanuelmfonseca/P2C2M.GMYC")` can identify model violations under a GMYC model.
 - `r pkg("MSCquartets")` provides methods for analyzing and using quartets displayed on a collection of gene trees, primarily to make inferences about the species tree or network under the multi-species coalescent model.
 - `r github("dosreislab/bppr")` can prepare the control files for doing model selection for comparing competing species trees using [BPP](https://github.com/bpp/bpp). A tutorial is available at [https://dosreislab.github.io/2018/08/31/bppr.html](https://dosreislab.github.io/2018/08/31/bppr.html).

--- a/Phylogenetics.md
+++ b/Phylogenetics.md
@@ -301,6 +301,7 @@ See the `r view("Epidemiology")` task view for details about packages useful for
 - `r pkg("tbea")` has code for post-analysis summarization and plotting of trace files from Bayesian phylogenetic programs such as Beast2, MrBayes, RevBayes, and MCMCTree. It offers a dedicated [website](https://gaballench.github.io/tbea/) with HTML-rendered vignettes.
 - `r github("lfabreti/convenience")` is a package for assessing Bayesian convergence both in continuous and discrete (topology) parameters from analyses using Bayesian phylogenetic programs.
 - `r pkg("EvoPhylo")` allows easy post-processing of macroevolutionary parameters from the outputs of Mr.Bayes and BEAST2.
+- `r github("ropensci/phruta")` has tools for retrieving data from GenBank and then concatenate them for phylogenetic analysis. It also does basic phylogenetic analysis using RAxML under the hood.
 
 ## References
 

--- a/Phylogenetics.md
+++ b/Phylogenetics.md
@@ -301,7 +301,7 @@ See the `r view("Epidemiology")` task view for details about packages useful for
 - `r pkg("tbea")` has code for post-analysis summarization and plotting of trace files from Bayesian phylogenetic programs such as Beast2, MrBayes, RevBayes, and MCMCTree. It offers a dedicated [website](https://gaballench.github.io/tbea/) with HTML-rendered vignettes.
 - `r github("lfabreti/convenience")` is a package for assessing Bayesian convergence both in continuous and discrete (topology) parameters from analyses using Bayesian phylogenetic programs.
 - `r pkg("EvoPhylo")` allows easy post-processing of macroevolutionary parameters from the outputs of Mr.Bayes and BEAST2.
-- `r github("ropensci/phruta")` has tools for retrieving data from GenBank and then concatenate them for phylogenetic analysis. It also does basic phylogenetic analysis using RAxML under the hood.
+- `r github("ropensci/phruta")` has tools for retrieving data from GenBank and then concatenating them for phylogenetic analysis. It also does basic phylogenetic analysis using RAxML under the hood.
 
 ## References
 

--- a/Phylogenetics.md
+++ b/Phylogenetics.md
@@ -297,7 +297,7 @@ See the `r view("Epidemiology")` task view for details about packages useful for
 - `r github("dosreislab/bppr")` can prepare the control files for doing model selection for comparing competing species trees using [BPP](https://github.com/bpp/bpp). A tutorial is available at [https://dosreislab.github.io/2018/08/31/bppr.html](https://dosreislab.github.io/2018/08/31/bppr.html)
 - `r github("dosreislab/mcmc3r")` can prepare the control files for carrying out divergence time estimation using MCMCtree from the suite [PAML](https://github.com/abacus-gene/paml). It also generates morphological alignments in phylip format for using continuous trait models in divergence time estimation in MCMCtree.
 - `r pkg("tbea")` has code for post-analysis summarization and plotting of trace files from Bayesian phylogenetic programs such as Beast2, MrBayes, RevBayes, and MCMCTree. It offers a dedicated [website](https://gaballench.github.io/tbea/) with HTML-rendered vignettes.
-
+- `r github("lfabreti/convenience")` is a package for assessing Bayesian convergence both in continuous and discrete (topology) parameters from analyses using Bayesian phylogenetic programs.
 
 ## References
 


### PR DESCRIPTION
These two packages are no longer on r-forge but on github instead.