### PR TITLE
Removes 'phenex' package reference

### DIFF
--- a/Phylogenetics.md
+++ b/Phylogenetics.md
@@ -45,7 +45,6 @@ Packages within the task view fall within one or more of the following task cate
 
 - `r pkg("phangorn")`,  `r pkg("TreeTools")` and `r pkg("TreeSearch")` contain functions for reading phylogenetic datasets into R and manipulating the resulting objects.
 - `r github("uyedaj/rphenoscate")` allows character matrices to be synthesized from semantic phenotype data, and facilitates analysis of "inapplicable" characters – such as morphological characters that are dependent on a parent trait – by constructing formal character hierarchies and the corresponding rate matrices (Tarasov 2023).
-- `r pkg("phenex")` facilitates the annotation of character matrices files with ontology terminology.
 - `r pkg("Claddis")` and `r pkg("EvoPhylo")` generate distance matrices from phylogenetic data, with functions to identify clusters and plot the corresponding morphospaces from these matrices.
 - `r pkg("geiger")` and `r pkg("phangorn")` contain functions to simulate phylogenetic data from phylogenetic trees.
 


### PR DESCRIPTION
Including it was the result of a mixup, see #49.

Closes #49.